### PR TITLE
Use the Name tag if it's a valid hostname

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.contaazul</groupId>
     <artifactId>turbine-ec2</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <packaging>pom</packaging>
     <name>turbine-ec2</name>
     <url>http://contaazul.com</url>

--- a/turbine-ec2-core/pom.xml
+++ b/turbine-ec2-core/pom.xml
@@ -3,11 +3,11 @@
     <parent>
       <groupId>com.contaazul</groupId>
       <artifactId>turbine-ec2</artifactId>
-      <version>1.0.1</version>
+      <version>1.0.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>turbine-ec2-core</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <packaging>jar</packaging>
     <dependencies>
         <dependency>

--- a/turbine-ec2-core/src/main/java/com/contaazul/turbine/ec2/EC2ToTurbineInstance.java
+++ b/turbine-ec2-core/src/main/java/com/contaazul/turbine/ec2/EC2ToTurbineInstance.java
@@ -37,7 +37,7 @@ public final class EC2ToTurbineInstance {
             ec2.getState().getName()
         ) == InstanceStateName.Running;
         return new com.netflix.turbine.discovery.Instance(
-                addr, this.cluster, state
+            addr, this.cluster, state
         );
     }
 

--- a/turbine-ec2-core/src/main/java/com/contaazul/turbine/ec2/EC2ToTurbineInstance.java
+++ b/turbine-ec2-core/src/main/java/com/contaazul/turbine/ec2/EC2ToTurbineInstance.java
@@ -3,6 +3,12 @@ package com.contaazul.turbine.ec2;
 import com.amazonaws.services.ec2.model.Instance;
 import com.amazonaws.services.ec2.model.InstanceStateName;
 
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.util.Optional;
+
 /**
  * Converts ec2 instances to turbine instances.
  */
@@ -26,12 +32,48 @@ public final class EC2ToTurbineInstance {
      * @return Turbine instance.
      */
     public com.netflix.turbine.discovery.Instance convert(final Instance ec2) {
-        final String dns = ec2.getPrivateIpAddress();
+        final String addr = this.address(ec2);
         final boolean state = InstanceStateName.fromValue(
             ec2.getState().getName()
         ) == InstanceStateName.Running;
         return new com.netflix.turbine.discovery.Instance(
-            dns, this.cluster, state
+                addr, this.cluster, state
         );
+    }
+
+    /**
+     * Get the address of a given ec2 instance.
+     * @param ec2 Instance
+     * @return Either private IP or Name (if accessible)
+     */
+    private String address(Instance ec2) {
+        final Optional<String> name = ec2.getTags().stream()
+                .filter(tag -> tag.getKey().equals("Name"))
+                .map(tag -> tag.getValue())
+                .findFirst();
+
+        if (name.isPresent()) {
+            final String host = name.get();
+            // check if port 80 or 8080 are up
+            if (ping(host, 80) || ping(host, 8080)) {
+                return host;
+            }
+        }
+        return ec2.getPrivateIpAddress();
+    }
+
+    /**
+     * Ping a host on a port.
+     * @param host Host
+     * @param port Port
+     * @return
+     */
+    public boolean ping(String host, int port) {
+        try (Socket socket = new Socket()) {
+            socket.connect(new InetSocketAddress(host, port), 100);
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
     }
 }

--- a/turbine-ec2-core/src/test/java/com/contaazul/turbine/ec2/EC2ToTurbineInstanceTest.java
+++ b/turbine-ec2-core/src/test/java/com/contaazul/turbine/ec2/EC2ToTurbineInstanceTest.java
@@ -36,7 +36,7 @@ public final class EC2ToTurbineInstanceTest {
     @Test
     public void convertsRunningInstancesWithName() {
         final String ip = "172.13.131.215";
-        final String name = "contaazul.com";
+        final String name = "localhost";
         final String cluster = "blah";
         final Instance ec2 = new Instance()
                 .withPrivateIpAddress(ip)
@@ -55,7 +55,7 @@ public final class EC2ToTurbineInstanceTest {
     @Test
     public void convertsRunningInstancesWithInvalidName() {
         final String ip = "172.13.131.215";
-        final String name = "contaazul.copppppp";
+        final String name = "asdasdasdasdasda";
         final String cluster = "blah";
         final Instance ec2 = new Instance()
                 .withPrivateIpAddress(ip)

--- a/turbine-ec2-core/src/test/java/com/contaazul/turbine/ec2/EC2ToTurbineInstanceTest.java
+++ b/turbine-ec2-core/src/test/java/com/contaazul/turbine/ec2/EC2ToTurbineInstanceTest.java
@@ -55,7 +55,7 @@ public final class EC2ToTurbineInstanceTest {
     @Test
     public void convertsRunningInstancesWithInvalidName() {
         final String ip = "172.13.131.215";
-        final String name = "asdasdasdasdasda";
+        final String name = "google.com";
         final String cluster = "blah";
         final Instance ec2 = new Instance()
                 .withPrivateIpAddress(ip)

--- a/turbine-ec2-core/src/test/java/com/contaazul/turbine/ec2/EC2ToTurbineInstanceTest.java
+++ b/turbine-ec2-core/src/test/java/com/contaazul/turbine/ec2/EC2ToTurbineInstanceTest.java
@@ -36,7 +36,7 @@ public final class EC2ToTurbineInstanceTest {
     @Test
     public void convertsRunningInstancesWithName() {
         final String ip = "172.13.131.215";
-        final String name = "localhost";
+        final String name = "google.com";
         final String cluster = "blah";
         final Instance ec2 = new Instance()
                 .withPrivateIpAddress(ip)
@@ -55,7 +55,7 @@ public final class EC2ToTurbineInstanceTest {
     @Test
     public void convertsRunningInstancesWithInvalidName() {
         final String ip = "172.13.131.215";
-        final String name = "google.com";
+        final String name = "asdasdasdasdasda";
         final String cluster = "blah";
         final Instance ec2 = new Instance()
                 .withPrivateIpAddress(ip)

--- a/turbine-ec2-core/src/test/java/com/contaazul/turbine/ec2/EC2ToTurbineInstanceTest.java
+++ b/turbine-ec2-core/src/test/java/com/contaazul/turbine/ec2/EC2ToTurbineInstanceTest.java
@@ -3,6 +3,7 @@ package com.contaazul.turbine.ec2;
 import com.amazonaws.services.ec2.model.Instance;
 import com.amazonaws.services.ec2.model.InstanceState;
 import com.amazonaws.services.ec2.model.InstanceStateName;
+import com.amazonaws.services.ec2.model.Tag;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
@@ -26,6 +27,44 @@ public final class EC2ToTurbineInstanceTest {
             .isNotNull()
             .matches(instance -> instance.getHostname().equals(ip))
             .matches(com.netflix.turbine.discovery.Instance::isUp);
+    }
+
+    /**
+     * {@link EC2ToTurbineInstance} can convert a running ec2 instance into
+     * a turbine instance with its name as address.
+     */
+    @Test
+    public void convertsRunningInstancesWithName() {
+        final String ip = "172.13.131.215";
+        final String name = "contaazul.com";
+        final String cluster = "blah";
+        final Instance ec2 = new Instance()
+                .withPrivateIpAddress(ip)
+                .withTags(new Tag("Name", name))
+                .withState(new InstanceState().withName(InstanceStateName.Running));
+        Assertions.assertThat(new EC2ToTurbineInstance(cluster).convert(ec2))
+                .isNotNull()
+                .matches(instance -> instance.getHostname().equals(name))
+                .matches(com.netflix.turbine.discovery.Instance::isUp);
+    }
+
+    /**
+     * {@link EC2ToTurbineInstance} can convert a running ec2 instance into
+     * a turbine instance with an invalid name as address.
+     */
+    @Test
+    public void convertsRunningInstancesWithInvalidName() {
+        final String ip = "172.13.131.215";
+        final String name = "contaazul.copppppp";
+        final String cluster = "blah";
+        final Instance ec2 = new Instance()
+                .withPrivateIpAddress(ip)
+                .withTags(new Tag("Name", name))
+                .withState(new InstanceState().withName(InstanceStateName.Running));
+        Assertions.assertThat(new EC2ToTurbineInstance(cluster).convert(ec2))
+                .isNotNull()
+                .matches(instance -> instance.getHostname().equals(ip))
+                .matches(com.netflix.turbine.discovery.Instance::isUp);
     }
 
     /**

--- a/turbine-ec2-web/pom.xml
+++ b/turbine-ec2-web/pom.xml
@@ -5,10 +5,10 @@
     <parent>
         <groupId>com.contaazul</groupId>
         <artifactId>turbine-ec2</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
     </parent>
     <artifactId>turbine-ec2-web</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <name>turbine-ec2-web</name>
     <packaging>war</packaging>
     <dependencies>


### PR DESCRIPTION
Some services may have virtual hosts sorcery and may not work if called by IP.

Assuming that the name that should be used is in the `Name` tag, this should work.